### PR TITLE
AbstractLeafletComponentState  updated

### DIFF
--- a/v-leaflet-shramov/src/main/java/org/vaadin/addon/leaflet/shramov/client/LeafletGoogleLayerState.java
+++ b/v-leaflet-shramov/src/main/java/org/vaadin/addon/leaflet/shramov/client/LeafletGoogleLayerState.java
@@ -1,6 +1,6 @@
 package org.vaadin.addon.leaflet.shramov.client;
 
-import org.vaadin.addon.leaflet.client.AbstractLeafletComponentState;
+import org.vaadin.addon.leaflet.shared.AbstractLeafletComponentState;
 
 public class LeafletGoogleLayerState extends AbstractLeafletComponentState {
 	public String layertype;


### PR DESCRIPTION
- Changed the import location of AbstractLeafletComponentState from
  org.vaadin.addon.leaflet.client to org.vaadin.addon.leaflet.shared
  within the LeafletGoogleLayerState class.
